### PR TITLE
raw client cannot connect to mocked server

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -14,13 +14,13 @@ logger = logging.getLogger("grpc_client")
 class ClientServerTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        # TODO: free port is better
         port = 8765
+        cls.port = 8765
         cls.event = threading.Event()
-        threading.Thread(target=_server, args=[port, cls.event]).start()
+        threading.Thread(target=_server, args=[cls.port, cls.event]).start()
         # wait for start
         time.sleep(1)
-        cls.client = Client("localhost:%d" % port)
+        cls.client = Client("localhost:%d" % cls.port)
 
     @classmethod
     def tearDownClass(cls):
@@ -43,3 +43,6 @@ class ClientServerTest(unittest.TestCase):
             logger.debug(message)
             assert 'mock message' in message
 
+        for _ in Client("localhost:%d" % self.port).execute('select * from galaxy'):
+            # The test should fail here
+            assert False


### PR DESCRIPTION
`make test` should fail. However, it passes....

```
(venv) yang.y@US-192435MBP pysqlflow ((HEAD detached at origin/develop)) $ make test
python3 setup.py test
/Users/yang.y/go/src/github.com/ktong/pysqlflow/venv/lib/python3.7/site-packages/setuptools/dist.py:470: UserWarning: Normalizing '0.1.0.dev' to '0.1.0.dev0'
  normalized_version,
running pytest
running egg_info
writing sqlflow.egg-info/PKG-INFO
writing dependency_links to sqlflow.egg-info/dependency_links.txt
writing entry points to sqlflow.egg-info/entry_points.txt
writing requirements to sqlflow.egg-info/requires.txt
writing top-level names to sqlflow.egg-info/top_level.txt
reading manifest file 'sqlflow.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'sqlflow.egg-info/SOURCES.txt'
running build_ext
======================================================== test session starts ========================================================
platform darwin -- Python 3.7.2, pytest-4.1.1, py-1.7.0, pluggy-0.8.1
rootdir: /Users/yang.y/go/src/github.com/ktong/pysqlflow, inifile: setup.cfg
collected 4 items

tests/test_client.py ..                                                                                                       [ 50%]
tests/test_magic.py .                                                                                                         [ 75%]
tests/test_version.py .                                                                                                       [100%]

========================================================= warnings summary ==========================================================
venv/lib/python3.7/site-packages/google/protobuf/internal/api_implementation.py:154
  /Users/yang.y/go/src/github.com/ktong/pysqlflow/venv/lib/python3.7/site-packages/google/protobuf/internal/api_implementation.py:154: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
    from google.protobuf.pyext import _message

venv/lib/python3.7/site-packages/google/protobuf/internal/containers.py:182
  /Users/yang.y/go/src/github.com/ktong/pysqlflow/venv/lib/python3.7/site-packages/google/protobuf/internal/containers.py:182: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
    MutableMapping = collections.MutableMapping

-- Docs: https://docs.pytest.org/en/latest/warnings.html
=============================================== 4 passed, 2 warnings in 1.37 seconds ================================================
```